### PR TITLE
feat: chatgpt-DOM 접근 구현

### DIFF
--- a/src/chrome-extension-boilerplate-react/src/pages/Content/index.js
+++ b/src/chrome-extension-boilerplate-react/src/pages/Content/index.js
@@ -2,6 +2,7 @@ const init = () => {
   const table = document.querySelectorAll('table');
   console.log('table 찾기');
   table.forEach((table, idx) => {
+    if (document.getElementById(`table_${idx}`)) return;
     table.setAttribute('class', 'border-2 border-black');
     table.setAttribute('id', `table_${idx}`);
 


### PR DESCRIPTION
#11 
확인해보니 이미 id가 적용된 table 태그여도 또 div태그로 감싸지는 문제가 있었습니다.
만약 id가 존재한다면, 이미 div 태그로 감싸져서 forEach 함수가 실행되지 않아도 되므로,
얼리 리턴 조건을 추가하여 중복 생성 문제를 해결했습니다.