### PR TITLE
feat: associate chatGPT with function to convert html to markdown

### DIFF
--- a/src/chrome-extension-boilerplate-react/src/pages/Content/index.js
+++ b/src/chrome-extension-boilerplate-react/src/pages/Content/index.js
@@ -1,3 +1,48 @@
+const saveTheMdToClipboard = async (text) => {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (err) {
+    console.error('Failed to copy!', err);
+  }
+};
+
+const convertHtmlToMd = (table, sort = 'left') => {
+  const tr = table.getElementsByTagName('tr');
+
+  // Table header
+  let header = '|';
+  const th = tr[0].getElementsByTagName('th');
+  for (let i = 0; i < th.length; i++) {
+    header += `${th[i].innerHTML}|`;
+  }
+
+  // Table separator
+  let separator = '|';
+  const sortOption = {
+    left: ':---|',
+    center: ':---:|',
+    right: '---:|',
+  };
+  for (let i = 0; i < table.rows[0].cells.length; i++) {
+    separator += sortOption[sort];
+  }
+
+  // Table rows
+  let rows = '';
+  for (let i = 1; i < tr.length; i++) {
+    let row = '|';
+    const td = tr[i].getElementsByTagName('td');
+    for (let j = 0; j < td.length; j++) {
+      row += `${td[j].innerHTML}|`;
+    }
+    rows += `${row}\n`;
+  }
+
+  saveTheMdToClipboard(`${header}\n${separator}\n${rows}`);
+
+  return;
+};
+
 const init = () => {
   const table = document.querySelectorAll('table');
   table.forEach((table, idx) => {
@@ -24,7 +69,7 @@ const init = () => {
 
     // Copy Button Event
     CopyButton.addEventListener('click', () => {
-      console.log(table.innerHTML);
+      convertHtmlToMd(table);
     });
   });
 };
@@ -44,6 +89,5 @@ const observer = new MutationObserver(function (mutations) {
 
 // 감시할 이벤트 타입과 옵션 설정
 const config = { childList: true, subtree: true };
-
 // 감시할 요소와 감시 옵션을 MutationObserver에 등록
 observer.observe(targetNode, config);


### PR DESCRIPTION
#12 
- 구현해두었던 변환 기능 익스텐션에 연결
- copy버튼 클릭 시 table.innerHTML을 넘겨주는데, 이 경우 html 태그가 아닌 string 데이터를 보내주게 됩니다. 
	변환 함수에서는 html태그를 분석하고 markdown으로 변환하는 것이기 때문에 html 태그로 받아야 했습니다.
	그래서 innerHTML이 아닌 table을 넘겨주는 것으로 수정하여 해결하였습니다.

### 구현 이미지

![구현화면](https://user-images.githubusercontent.com/85178602/223694268-6b1d746c-e2fc-46f8-a47b-ac4a1adb3852.gif)