### PR TITLE
feat: 복사버튼 클릭 시 사용자 알림 추가

### DIFF
--- a/src/chrome-extension-boilerplate-react/src/pages/Content/index.js
+++ b/src/chrome-extension-boilerplate-react/src/pages/Content/index.js
@@ -1,3 +1,15 @@
+const copyBtnDefaultText = 'Copy table';
+const copyBtnDefaultStyle =
+  'border border-black text-xs p-1 px-2 mb-3 rounded font-semibold hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200';
+
+const copyCompleteNotification = (idx) => {
+  const targetBtn = document.getElementById(`table_copy_button_${idx}`);
+  targetBtn.innerHTML = `<div style="display: flex; justify-content: center; align-items: center;"><svg width="16" height="16" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2Zm3.22 6.97-4.47 4.47-1.97-1.97a.75.75 0 0 0-1.06 1.06l2.5 2.5a.75.75 0 0 0 1.06 0l5-5a.75.75 0 1 0-1.06-1.06Z" fill="#2ECC70"/></svg> <span style="margin-left: 5px;">copy completed!</span></div>`;
+  setTimeout(() => {
+    targetBtn.innerHTML = copyBtnDefaultText;
+  }, 3000);
+};
+
 const saveTheMdToClipboard = async (text) => {
   try {
     await navigator.clipboard.writeText(text);
@@ -51,11 +63,8 @@ const init = () => {
     // 각 테이블 마다 버튼 생성
     const copyButton = document.createElement('button');
     copyButton.setAttribute('id', `table_copy_button_${idx}`);
-    copyButton.setAttribute(
-      'class',
-      'border border-black text-xs p-0.5 px-1 mb-1 rounded font-semibold hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200'
-    );
-    copyButton.innerText = 'copy table';
+    copyButton.setAttribute('class', `${copyBtnDefaultStyle}`);
+    copyButton.innerText = copyBtnDefaultText;
 
     // div 요소 생성 및 속성 설정
     const div = document.createElement('div');
@@ -71,6 +80,7 @@ const init = () => {
 
     // Copy Button Event
     copyButton.addEventListener('click', () => {
+      copyCompleteNotification(idx);
       convertHtmlToMd(table);
     });
   });

--- a/src/chrome-extension-boilerplate-react/src/pages/Content/index.js
+++ b/src/chrome-extension-boilerplate-react/src/pages/Content/index.js
@@ -2,23 +2,32 @@ const copyBtnDefaultText = 'Copy table';
 const copyBtnDefaultStyle =
   'border border-black text-xs p-1 px-2 mb-3 rounded font-semibold hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200';
 
-const copyCompleteNotification = (idx) => {
-  const targetBtn = document.getElementById(`table_copy_button_${idx}`);
+const copyCompleteNotification = (targetIdx, state = true) => {
+  const targetBtn = document.getElementById(`table_copy_button_${targetIdx}`);
+  if (!state) {
+    targetBtn.innerHTML = `<div style="display: flex; justify-content: center; align-items: center;"><svg width="16" height="16" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2Zm3.53 6.47-.084-.073a.75.75 0 0 0-.882-.007l-.094.08L12 10.939l-2.47-2.47-.084-.072a.75.75 0 0 0-.882-.007l-.094.08-.073.084a.75.75 0 0 0-.007.882l.08.094L10.939 12l-2.47 2.47-.072.084a.75.75 0 0 0-.007.882l.08.094.084.073a.75.75 0 0 0 .882.007l.094-.08L12 13.061l2.47 2.47.084.072a.75.75 0 0 0 .882.007l.094-.08.073-.084a.75.75 0 0 0 .007-.882l-.08-.094L13.061 12l2.47-2.47.072-.084a.75.75 0 0 0 .007-.882l-.08-.094-.084-.073.084.073Z" fill="#E84B3C"/></svg> <span style="margin-left: 5px;">copy failed</span></div>`;
+    setTimeout(() => {
+      targetBtn.innerHTML = copyBtnDefaultText;
+    }, 1500);
+    return;
+  }
   targetBtn.innerHTML = `<div style="display: flex; justify-content: center; align-items: center;"><svg width="16" height="16" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2Zm3.22 6.97-4.47 4.47-1.97-1.97a.75.75 0 0 0-1.06 1.06l2.5 2.5a.75.75 0 0 0 1.06 0l5-5a.75.75 0 1 0-1.06-1.06Z" fill="#2ECC70"/></svg> <span style="margin-left: 5px;">copy completed!</span></div>`;
   setTimeout(() => {
     targetBtn.innerHTML = copyBtnDefaultText;
-  }, 3000);
+  }, 1500);
 };
 
-const saveTheMdToClipboard = async (text) => {
+const saveTheMdToClipboard = async (text, targetIdx) => {
   try {
     await navigator.clipboard.writeText(text);
+    copyCompleteNotification(targetIdx);
   } catch (err) {
+    copyCompleteNotification(targetIdx, false);
     console.error('Failed to copy!', err);
   }
 };
 
-const convertHtmlToMd = (table, sort = 'left') => {
+const convertHtmlToMd = (table, targetIdx, sort = 'left') => {
   const tr = table.getElementsByTagName('tr');
   // Table header
   let header = '|';
@@ -49,7 +58,7 @@ const convertHtmlToMd = (table, sort = 'left') => {
     rows += `${row}\n`;
   }
 
-  saveTheMdToClipboard(`${header}\n${separator}\n${rows}`);
+  saveTheMdToClipboard(`${header}\n${separator}\n${rows}`, targetIdx);
 
   return;
 };
@@ -80,8 +89,7 @@ const init = () => {
 
     // Copy Button Event
     copyButton.addEventListener('click', () => {
-      copyCompleteNotification(idx);
-      convertHtmlToMd(table);
+      convertHtmlToMd(table, idx);
     });
   });
 };

--- a/src/chrome-extension-boilerplate-react/src/pages/Content/index.js
+++ b/src/chrome-extension-boilerplate-react/src/pages/Content/index.js
@@ -83,7 +83,7 @@ const targetNode = document.querySelector('main > div > div > div ');
 const observer = new MutationObserver(function (mutations) {
   mutations.forEach(function (mutation) {
     // 새로운 노드가 추가되었을 때 처리할 내용 작성
-    if (mutation.previousSibling?.nodeName === 'THEAD') {
+    if (mutation?.type === 'childList') {
       init();
     }
   });

--- a/src/chrome-extension-boilerplate-react/src/pages/Content/index.js
+++ b/src/chrome-extension-boilerplate-react/src/pages/Content/index.js
@@ -8,7 +8,6 @@ const saveTheMdToClipboard = async (text) => {
 
 const convertHtmlToMd = (table, sort = 'left') => {
   const tr = table.getElementsByTagName('tr');
-
   // Table header
   let header = '|';
   const th = tr[0].getElementsByTagName('th');
@@ -48,27 +47,30 @@ const init = () => {
   table.forEach((table, idx) => {
     if (document.getElementById(`table_${idx}`)) return;
     table.setAttribute('id', `table_${idx}`);
-
+    table.setAttribute('class', 'm-0');
     // 각 테이블 마다 버튼 생성
-    const CopyButton = document.createElement('button');
-    CopyButton.setAttribute('id', `table_copy_button_${idx}`);
-    CopyButton.setAttribute('class', 'border-2 border-black ml-[428px]');
-    CopyButton.innerText = 'copy';
+    const copyButton = document.createElement('button');
+    copyButton.setAttribute('id', `table_copy_button_${idx}`);
+    copyButton.setAttribute(
+      'class',
+      'border border-black text-xs p-0.5 px-1 mb-1 rounded font-semibold hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200'
+    );
+    copyButton.innerText = 'copy table';
 
     // div 요소 생성 및 속성 설정
     const div = document.createElement('div');
     div.classList.add('table-wrapper');
-    div.setAttribute('class', 'flex-row w-full');
+    div.setAttribute('class', 'w-full flex flex-col relative items-end mt-5');
 
     // div 부모 요소에 버튼 추가
-    div.appendChild(CopyButton);
+    div.appendChild(copyButton);
 
     // table 요소를 div 요소로 감싸기
     table.parentNode.insertBefore(div, table);
     div.appendChild(table);
 
     // Copy Button Event
-    CopyButton.addEventListener('click', () => {
+    copyButton.addEventListener('click', () => {
       convertHtmlToMd(table);
     });
   });


### PR DESCRIPTION
# 17

- 복사 버튼을 누르고 클립보드에 변환된 table markdown이 복사 완료되면 사용자에게 알림
- 추가로 실패 시 알림도 구현하였음

### 구현 이미지

완료 알림
![완료](https://user-images.githubusercontent.com/85178602/224228407-003d9a48-6196-41d0-adc4-f134b1f55a0c.gif)

실패 알림
![실패](https://user-images.githubusercontent.com/85178602/224228418-19d4a952-c43c-483a-9ef4-3ac73f78842b.gif)

알림이 사라지는 시간은 완료 알림 시간으로 봐주세요(1.5초)
실패 알림은 3초로 설정되어있는 이미지이며, 너무 느린 것 같아 1.5초로 변경했습니다. 모양만 참고해주세요!

### 참고사항

@baechanghyeon 창현님이 구현한 버튼 css 코드를 pull한 뒤 작업한 내용입니다.
창현님의 pr을 먼저 merge한 뒤 제 pr을 approve & merge해주세요!
